### PR TITLE
Switch to the V2 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+- Switch to the V2 API
+  - Add `id` attribute to Task
+  - Make `name` optional
+  - Add optional `queue` attribute to Task that defaults to `default`
+  - Remove `description` from Task
+
 ## [0.1.2] - 2022-01-20
 
 - Add `RequestValidator` to validate that webhooks came from Mergent's API

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -9,7 +9,7 @@ export default class Client {
   }
 
   async post<T>(resource: string, params: object): Promise<T> {
-    const url = `https://api.mergent.co/v1/${resource}`;
+    const url = `https://api.mergent.co/v2/${resource}`;
     const headers = {
       Authorization: `Bearer ${this.config.apiKey}`,
       "Content-Type": "application/json",

--- a/src/resources/Tasks.ts
+++ b/src/resources/Tasks.ts
@@ -9,6 +9,7 @@ export default class Tasks {
   }
 
   create(params: CreateTaskParams): Promise<Task> {
-    return this.client.post("tasks", params);
+    const defaultParams = { queue: "default" };
+    return this.client.post("tasks", { ...defaultParams, ...params });
   }
 }

--- a/src/types/Task.ts
+++ b/src/types/Task.ts
@@ -1,14 +1,15 @@
 import Request from "./Request";
 
 export default interface Task {
-  name: string;
-  description: string;
+  id: string;
+  name?: string;
+  queue: string;
   status: string;
 }
 
 export interface CreateTaskParams {
   name?: string;
-  description?: string;
+  queue?: string;
   request: Request;
 
   /**

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -24,7 +24,7 @@ describe("#post", () => {
 
     await client.post("resource", params);
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.mergent.co/v1/resource",
+      "https://api.mergent.co/v2/resource",
       {
         method: "POST",
         headers: {

--- a/test/resources/Tasks.test.ts
+++ b/test/resources/Tasks.test.ts
@@ -6,7 +6,24 @@ jest.mock("../../src/Client");
 const client = new Client({ apiKey: "" });
 const tasks = new Tasks(client);
 
-test("#create", async () => {
-  tasks.create({ request: { url: "" } });
-  expect(client.post).toHaveBeenCalledTimes(1);
+describe("#create", () => {
+  describe("with a queue param", () => {
+    test("makes a request to create a Task on the specified queue", async () => {
+      tasks.create({ queue: "foo", request: { url: "" } });
+      expect(client.post).toHaveBeenCalledWith("tasks", {
+        queue: "foo",
+        request: { url: "" },
+      });
+    });
+  });
+
+  describe("without a queue param", () => {
+    test("makes a request to create a Task on the default queue", async () => {
+      tasks.create({ request: { url: "" } });
+      expect(client.post).toHaveBeenCalledWith("tasks", {
+        queue: "default",
+        request: { url: "" },
+      });
+    });
+  });
 });


### PR DESCRIPTION
Switch to the V2 API
  - Add `id` attribute to Task
  - Make `name` optional
  - Add optional `queue` attribute to Task that defaults to `default`
  - Remove `description` from Task
