### PR TITLE
Fix for when error JSON was not parsed correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fix for when error JSON was not parsed correctly (fixes [#181](https://github.com/mergentlabs/mergent-js/issues/181))
+
 ## [1.3.0] - 2022-11-03
 
 - Add method to run a Task immediately (`tasks.run`)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,8 +4,23 @@ export interface MergentAPIErrorParams {
   message: string;
 }
 
-export class MergentAPIError extends Error {
+export class MergentError extends Error {
+  constructor(message?: string) {
+    super(message);
+    Object.setPrototypeOf(this, MergentError.prototype);
+  }
+}
+
+export class MergentAPIError extends MergentError {
   constructor(params: MergentAPIErrorParams) {
     super(params.message);
+    Object.setPrototypeOf(this, MergentAPIError.prototype);
+  }
+}
+
+export class MergentAPIInvalidJSONError extends MergentError {
+  constructor() {
+    super("Invalid JSON received from the Mergent API");
+    Object.setPrototypeOf(this, MergentAPIInvalidJSONError.prototype);
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,6 +2,8 @@
 
 export interface MergentAPIErrorParams {
   message: string;
+  param?: string;
+  errors?: MergentAPIErrorParams[];
 }
 
 export class MergentError extends Error {
@@ -12,9 +14,18 @@ export class MergentError extends Error {
 }
 
 export class MergentAPIError extends MergentError {
+  param?: string | undefined;
+
+  errors?: MergentAPIError[] | undefined;
+
   constructor(params: MergentAPIErrorParams) {
     super(params.message);
     Object.setPrototypeOf(this, MergentAPIError.prototype);
+
+    this.param = params.param;
+    this.errors = params.errors?.map(
+      (errorParams) => new MergentAPIError(errorParams)
+    );
   }
 }
 

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -13,9 +13,29 @@ describe("MergentError", () => {
 
 describe("MergentAPIError", () => {
   it("can be initailized from a Mergent API JSON response", () => {
-    const message = "something went wrong";
-    const error = new MergentAPIError({ message });
-    expect(error.message).toBe(message);
+    const json = {
+      message: "something went wrong",
+      errors: [
+        { message: "param0 error", param: "param0" },
+        { message: "param1 error", param: "param1" },
+        { message: "another error" },
+      ],
+    };
+    const error = new MergentAPIError(json);
+    expect(error.message).toBe(json.message);
+    expect(error.errors).toHaveLength(3);
+
+    const e0 = error.errors && error.errors[0];
+    expect(e0?.message).toBe("param0 error");
+    expect(e0?.param).toBe("param0");
+
+    const e1 = error.errors && error.errors[1];
+    expect(e1?.message).toBe("param1 error");
+    expect(e1?.param).toBe("param1");
+
+    const e2 = error.errors && error.errors[2];
+    expect(e2?.message).toBe("another error");
+    expect(e2?.param).toBeUndefined();
   });
 
   it("has the correct prototype", () => {

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,0 +1,32 @@
+import {
+  MergentError,
+  MergentAPIError,
+  MergentAPIInvalidJSONError,
+} from "../src/errors";
+
+describe("MergentError", () => {
+  it("has the correct prototype", () => {
+    const error = new MergentError("");
+    expect(error instanceof MergentError).toBe(true);
+  });
+});
+
+describe("MergentAPIError", () => {
+  it("can be initailized from a Mergent API JSON response", () => {
+    const message = "something went wrong";
+    const error = new MergentAPIError({ message });
+    expect(error.message).toBe(message);
+  });
+
+  it("has the correct prototype", () => {
+    const error = new MergentAPIError({ message: "" });
+    expect(error instanceof MergentAPIError).toBe(true);
+  });
+});
+
+describe("MergentAPIInvalidJSONError", () => {
+  it("has the correct prototype", () => {
+    const error = new MergentAPIInvalidJSONError();
+    expect(error instanceof MergentAPIInvalidJSONError).toBe(true);
+  });
+});


### PR DESCRIPTION
This is a fix for when Mergent API error JSON was not parsed correctly. 

## Before
These screenshots from Eric in Discord (maverickdotdev) demonstrate incorrect API error parsing:
![image](https://user-images.githubusercontent.com/1286597/202830783-7e9cfbab-2502-41c4-b4bc-7a8651b275c8.png)
![image](https://user-images.githubusercontent.com/1286597/202830725-edafff34-5904-4d6c-93ae-da70b783dc77.png)