### PR TITLE
Replace delay/duration with new duration string, removing ISO 8601 Durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+- Use friendlier duration format (e.g., `2s`, `30m`, `24h`)
+- Remove days, weeks, months, and years from `Duration` to avoid confusion
+  across daylight savings time zone transitions
+- Remove `tinyduration` dependency
+
 ## [1.3.1] - 2022-11-18
 
 - Fix for when error JSON was not parsed correctly (fixes [#181](https://github.com/mergentlabs/mergent-js/issues/181))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.0",
-        "tinyduration": "^3.2.2"
+        "node-fetch": "^2.6.0"
       },
       "devDependencies": {
         "@tsconfig/strictest": "^1.0.2",
@@ -5659,11 +5658,6 @@
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
     },
-    "node_modules/tinyduration": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.2.3.tgz",
-      "integrity": "sha512-hyczESnHcW45T3xoEl1YzeKuVLauZeMDTVN0Yg7mGs04UVvObl4Ti0nMO6nDi+rA0CVY5XSUmOacr1Yqm0O73Q=="
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -10384,11 +10378,6 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
-    },
-    "tinyduration": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.2.3.tgz",
-      "integrity": "sha512-hyczESnHcW45T3xoEl1YzeKuVLauZeMDTVN0Yg7mGs04UVvObl4Ti0nMO6nDi+rA0CVY5XSUmOacr1Yqm0O73Q=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "package": "npm run build && npm pack"
   },
   "dependencies": {
-    "node-fetch": "^2.6.0",
-    "tinyduration": "^3.2.2"
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@tsconfig/strictest": "^1.0.2",

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -1,6 +1,25 @@
-import { serialize } from "tinyduration";
 import type Duration from "./types/Duration";
 
-export const iso8601Duration = (duration: Duration) => serialize(duration);
+export function durationToString(duration: Duration): string | undefined {
+  let str = "";
+
+  if (duration.hours !== undefined) {
+    str += `${duration.hours}h`;
+  }
+
+  if (duration.minutes !== undefined) {
+    str += `${duration.minutes}m`;
+  }
+
+  if (duration.seconds !== undefined) {
+    str += `${duration.seconds}s`;
+  }
+
+  if (str === "") {
+    return undefined;
+  }
+
+  return str;
+}
 
 export default {};

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -3,15 +3,15 @@ import type Duration from "./types/Duration";
 export function durationToString(duration: Duration): string | undefined {
   let str = "";
 
-  if (duration.hours !== undefined) {
+  if (duration.hours) {
     str += `${duration.hours}h`;
   }
 
-  if (duration.minutes !== undefined) {
+  if (duration.minutes) {
     str += `${duration.minutes}m`;
   }
 
-  if (duration.seconds !== undefined) {
+  if (duration.seconds) {
     str += `${duration.seconds}s`;
   }
 

--- a/src/resources/Tasks.ts
+++ b/src/resources/Tasks.ts
@@ -1,4 +1,4 @@
-import { iso8601Duration } from "../duration";
+import { durationToString } from "../duration";
 import type Client from "../Client";
 import type Task from "../types/Task";
 import type { CreateTaskParams, UpdateTaskParams } from "../types/Task";
@@ -47,7 +47,7 @@ export default class Tasks {
       scheduledFor: undefined,
       delay:
         typeof params.delay === "object"
-          ? iso8601Duration(params.delay)
+          ? durationToString(params.delay)
           : params.delay,
     };
   }

--- a/src/types/Duration.ts
+++ b/src/types/Duration.ts
@@ -1,10 +1,4 @@
-/// Inspired by the proposed ECMAScript Temporal API.
-/// Learn more: https://tc39.es/proposal-temporal/docs/duration.html
 export default interface Duration {
-  years?: number;
-  months?: number;
-  weeks?: number;
-  days?: number;
   hours?: number;
   minutes?: number;
   seconds?: number;

--- a/src/types/Task.ts
+++ b/src/types/Task.ts
@@ -20,9 +20,6 @@ export interface CreateTaskParams {
   scheduled_for?: string;
   scheduledFor?: Date;
 
-  /**
-   * ISO 8601 duration
-   */
   delay?: Duration | string;
 }
 

--- a/test/duration.test.ts
+++ b/test/duration.test.ts
@@ -1,25 +1,25 @@
 import type Duration from "../src/types/Duration";
-import { iso8601Duration } from "../src/duration";
+import { durationToString } from "../src/duration";
 
-describe("iso8601Duration()", () => {
-  test("returns the ISO 8601 representation of the Duration", () => {
-    const cases: [string, Duration][] = [
-      ["PT5M", { minutes: 5 }],
-      ["P1M", { months: 1 }],
-      ["PT1M", { minutes: 1 }],
-      ["P12W", { weeks: 12 }],
-      ["P12Y10M", { years: 12, months: 10 }],
-      ["P12Y10M13D", { years: 12, months: 10, days: 13 }],
-      ["P2DT1M", { days: 2, minutes: 1 }],
-      ["PT0.5M", { minutes: 0.5 }],
-      ["P0.5YT0.5M", { years: 0.5, minutes: 0.5 }],
-      ["PT0S", { months: 0 }],
-      ["PT0S", { weeks: 0 }],
-      ["PT0S", { days: 0 }],
+describe("duration()", () => {
+  test("returns the string representation of the Duration", () => {
+    const cases: [string | undefined, Duration][] = [
+      ["1s", { seconds: 1 }],
+      ["100s", { seconds: 100 }],
+      ["5m", { minutes: 5 }],
+      ["1.5h", { hours: 1.5 }],
+      ["1.5h2m60s", { hours: 1.5, minutes: 2, seconds: 60 }],
+      ["2h45m", { hours: 2, minutes: 45 }],
+      ["2h", { hours: 2 }],
+      ["0s", { seconds: 0 }],
+      ["0s", { seconds: 0 }],
+      ["0s", { seconds: 0 }],
+      [undefined, {}],
     ];
-    cases.forEach(([expectedISOString, duration]) => {
-      const actualISOString = iso8601Duration(duration);
-      expect(actualISOString).toStrictEqual(expectedISOString);
+
+    cases.forEach(([expected, input]) => {
+      const actual = durationToString(input);
+      expect(actual).toStrictEqual(expected);
     });
   });
 });

--- a/test/duration.test.ts
+++ b/test/duration.test.ts
@@ -11,9 +11,9 @@ describe("duration()", () => {
       ["1.5h2m60s", { hours: 1.5, minutes: 2, seconds: 60 }],
       ["2h45m", { hours: 2, minutes: 45 }],
       ["2h", { hours: 2 }],
-      ["0s", { seconds: 0 }],
-      ["0s", { seconds: 0 }],
-      ["0s", { seconds: 0 }],
+      [undefined, { seconds: 0 }],
+      [undefined, { minutes: 0 }],
+      [undefined, { hours: 0 }],
       [undefined, {}],
     ];
 

--- a/test/resources/Tasks.test.ts
+++ b/test/resources/Tasks.test.ts
@@ -55,22 +55,22 @@ describe("#create", () => {
   });
 
   describe("with a delay param", () => {
-    test("makes a request to create a Task, setting the delay to the specified Duration serialized to an ISO 8601 Duration string", () => {
+    test("makes a request to create a Task, setting the delay to the specified Duration serialized to a duration string", () => {
       const delay: Duration = { minutes: 7, seconds: 3 };
       tasks.create({ request: { url: "" }, delay });
       expect(client.post).toHaveBeenCalledWith("tasks", {
         queue: "default",
         request: { url: "" },
-        delay: "PT7M3S",
+        delay: "7m3s",
       });
     });
 
-    test("makes a request to create a Task, setting the delay to the specified ISO 8601 Duration string", () => {
-      tasks.create({ request: { url: "" }, delay: "PT5M" });
+    test("makes a request to create a Task, setting the delay to the specified string", () => {
+      tasks.create({ request: { url: "" }, delay: "5m" });
       expect(client.post).toHaveBeenCalledWith("tasks", {
         queue: "default",
         request: { url: "" },
-        delay: "PT5M",
+        delay: "5m",
       });
     });
   });
@@ -92,7 +92,7 @@ describe("#update", () => {
       delay: { minutes: 5 },
     });
     expect(client.patch).toHaveBeenCalledWith(`tasks/${id}`, {
-      delay: "PT5M",
+      delay: "5m",
     });
   });
 
@@ -119,18 +119,18 @@ describe("#update", () => {
   });
 
   describe("with a delay param", () => {
-    test("makes a request to update a Task, setting the delay to the specified Duration serialized to an ISO 8601 Duration string", () => {
+    test("makes a request to update a Task, setting the delay to the specified Duration serialized to a duration string", () => {
       const delay: Duration = { minutes: 7, seconds: 3 };
       tasks.update(id, { delay });
       expect(client.patch).toHaveBeenCalledWith(`tasks/${id}`, {
-        delay: "PT7M3S",
+        delay: "7m3s",
       });
     });
 
-    test("makes a request to create a Task, setting the delay to the specified ISO 8601 Duration string", () => {
-      tasks.update(id, { delay: "PT5M" });
+    test("makes a request to create a Task, setting the delay to the specified string", () => {
+      tasks.update(id, { delay: "5m" });
       expect(client.patch).toHaveBeenCalledWith(`tasks/${id}`, {
-        delay: "PT5M",
+        delay: "5m",
       });
     });
   });


### PR DESCRIPTION
- Use friendlier duration format (e.g., `2s`, `30m`, `24h`)
- Remove days, weeks, months, and years from `Duration` to avoid confusion across daylight savings time zone transitions
- Remove `tinyduration` dependency