### PR TITLE
feat(schedule): crud

### DIFF
--- a/src/resources/Schedules.ts
+++ b/src/resources/Schedules.ts
@@ -1,6 +1,9 @@
 import type Client from "../Client";
 import type Schedule from "../types/Schedule";
-import type { CreateScheduleParams } from "../types/Schedule";
+import type {
+  CreateScheduleParams,
+  UpdateScheduleParams,
+} from "../types/Schedule";
 
 export default class Schedules {
   private client: Client;
@@ -12,5 +15,21 @@ export default class Schedules {
   create(params: CreateScheduleParams): Promise<Schedule> {
     const defaultParams = { queue: "default" };
     return this.client.post("schedules", { ...defaultParams, ...params });
+  }
+
+  retrieve(id: string): Promise<Schedule> {
+    return this.client.get(`schedules/${id}`);
+  }
+
+  update(id: string, params: UpdateScheduleParams): Promise<Schedule> {
+    return this.client.patch(`schedules/${id}`, params);
+  }
+
+  list(): Promise<[Schedule]> {
+    return this.client.get("schedules");
+  }
+
+  delete(id: string): Promise<void> {
+    return this.client.delete(`schedules/${id}`);
   }
 }

--- a/src/types/Schedule.ts
+++ b/src/types/Schedule.ts
@@ -5,7 +5,7 @@ export default interface Schedule {
   name?: string;
   description?: string;
   queue: string;
-  status: string;
+  paused?: boolean;
   cron?: string;
   rrule?: string;
   dtstart?: string;
@@ -15,6 +15,7 @@ export interface CreateScheduleParams {
   name?: string;
   description?: string;
   queue?: string;
+  paused?: boolean;
   request: Request;
 
   /**

--- a/src/types/Schedule.ts
+++ b/src/types/Schedule.ts
@@ -32,3 +32,5 @@ export interface CreateScheduleParams {
    */
   dtstart?: string;
 }
+
+export type UpdateScheduleParams = Partial<CreateScheduleParams>;

--- a/test/resources/Schedules.test.ts
+++ b/test/resources/Schedules.test.ts
@@ -29,4 +29,109 @@ describe("#create", () => {
       });
     });
   });
+
+  describe("with a cron param", () => {
+    it("makes a request to create a Schedule, setting the cron string", () => {
+      schedules.create({ request: { url: "" }, cron: "0 0 7 * *" });
+      expect(client.post).toHaveBeenCalledWith("schedules", {
+        queue: "default",
+        request: { url: "" },
+
+        cron: "0 0 7 * *",
+      });
+    });
+  });
+
+  describe("with an rrule param", () => {
+    it("makes a request to create a Schedule, setting the rrule string", () => {
+      schedules.create({ request: { url: "" }, rrule: "FREQ=HOURLY" });
+      expect(client.post).toHaveBeenCalledWith("schedules", {
+        queue: "default",
+        request: { url: "" },
+        rrule: "FREQ=HOURLY",
+      });
+    });
+  });
+
+  describe("with an rrule + dtstart param", () => {
+    it("makes a request to create a Schedule, setting the rrule string", () => {
+      schedules.create({
+        request: { url: "" },
+        rrule: "FREQ=HOURLY",
+        dtstart: "2024-5-01T15:53:05Z",
+      });
+      expect(client.post).toHaveBeenCalledWith("schedules", {
+        queue: "default",
+        request: { url: "" },
+        rrule: "FREQ=HOURLY",
+        dtstart: "2024-5-01T15:53:05Z",
+      });
+    });
+  });
+});
+
+describe("#retrieve", () => {
+  it("makes a request to retrieve the specified Schedule", () => {
+    const id = "28081772-5698-4b70-b8ae-2b3594d33394";
+    schedules.retrieve(id);
+    expect(client.get).toHaveBeenCalledWith(`schedules/${id}`);
+  });
+});
+
+describe("#update", () => {
+  const id = "28081772-5698-4b70-b8ae-2b3594d33394";
+  it("makes a request to update the specified Schedule", () => {
+    schedules.update(id, {
+      paused: true,
+    });
+    expect(client.patch).toHaveBeenCalledWith(`schedules/${id}`, {
+      paused: true,
+    });
+  });
+});
+
+describe("#update:cron", () => {
+  const id = "28081772-5698-4b70-b8ae-2b3594d33369";
+  describe("with a cron param", () => {
+    it("makes a request to update a Schedule, setting the cron string", () => {
+      schedules.update(id, {
+        cron: "0 0 7 * *",
+      });
+      expect(client.patch).toHaveBeenCalledWith(`schedules/${id}`, {
+        cron: "0 0 7 * *",
+      });
+    });
+  });
+});
+
+describe("#update:rrule", () => {
+  const id = "28081772-5698-4b70-b8ae-2b3594d33420";
+
+  describe("with an rrule param", () => {
+    it("makes a request to update a Schedule, setting the rrule string", () => {
+      schedules.update(id, { rrule: "FREQ=HOURLY" });
+      expect(client.patch).toHaveBeenCalledWith(`schedules/${id}`, {
+        rrule: "FREQ=HOURLY",
+      });
+    });
+  });
+
+  describe("with a dtstart param", () => {
+    it("makes a request to update a Schedule, setting the rrule string", () => {
+      schedules.update(id, {
+        dtstart: "2024-5-01T15:53:05Z",
+      });
+      expect(client.patch).toHaveBeenCalledWith(`schedules/${id}`, {
+        dtstart: "2024-5-01T15:53:05Z",
+      });
+    });
+  });
+});
+
+describe("#delete", () => {
+  it("makes a request to delete the specified Schedule", () => {
+    const id = "28081772-5698-4b70-b8ae-2b3594d33394";
+    schedules.delete(id);
+    expect(client.delete).toHaveBeenCalledWith(`schedules/${id}`);
+  });
 });


### PR DESCRIPTION
I'm using this library and wanted to use schedules, however, only the create() method was implemented. I've added the rest according to the API reference.